### PR TITLE
feat: Implement forecasting enhancements and CV

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -185,23 +185,26 @@ app_ui <- function(request) {
           sidebar = bslib::sidebar(
             title = "Config",
             width = 350,
-            # Placeholder for Validation Configuration?
-            tags$p("Placeholder for validation settings controls (if any)"),
-            tags$p("Placeholder for model selection for comparison?")
+            uiOutput("cv_model_selector_ui"), # Dynamic UI for model selection
+            hr(),
+            h5("Cross-Validation Parameters:"),
+            numericInput("cv_initial_window", "Initial Training Window (periods)", value = 90, min = 10),
+            numericInput("cv_horizon", "Forecast Horizon (per fold)", value = 30, min = 1),
+            numericInput("cv_skip", "Skip Periods (between folds)", value = 15, min = 0),
+            checkboxInput("cv_cumulative", "Cumulative Training Window", value = FALSE),
+            actionButton("run_cv_button", "Run Cross-Validation", icon = icon("play-circle"), class = "btn-primary")
           ), # End sidebar
           # Main content for Validation panel
           bslib::card(
-            bslib::card_header("Validation results"),
+            bslib::card_header("Cross-Validation Mean Metrics"),
             bslib::card_body(
-              # Placeholder for validation outputs
-              tags$p("Placeholder for validation results display (e.g., backtesting metrics)")
+              DT::dataTableOutput("cv_results_table_output")
             )
           ),
           bslib::card(
-            bslib::card_header("Model comparison"),
+            bslib::card_header("Cross-Validation Metric Distributions"),
             bslib::card_body(
-              # Placeholder for comparison outputs
-              tags$p("Placeholder for model comparison display (e.g., plots/tables)")
+              plotOutput("cv_results_plot_output")
             )
           )
         ) # End layout_sidebar for Validation panel


### PR DESCRIPTION
This commit introduces several major features and fixes:

1.  **Save/Load Functionality:**
    *   I fixed a bug ("tentativa de aplicar una no-función") in the session saving mechanism by adding checks for reactive accessors.
    *   I implemented session loading functionality, allowing you to restore application state from a saved RDS file.

2.  **Holiday & Regressor Integration:**
    *   I reviewed and confirmed ARIMA and GAM holiday processing using global holiday data.
    *   I removed Prophet-specific holiday inputs, ensuring Prophet now uses the global holiday configuration. This simplifies holiday management.

3.  **Hyperparameter Tuning Framework:**
    *   I reviewed existing XGBoost/RF tuning.
    *   I outlined strategies for future extensions to ARIMA and ETS tuning.

4.  **Validation Section (Time Series Cross-Validation):**
    *   I added a new "Validation" section to the UI.
    *   I implemented server-side logic for time series cross-validation using `timetk::time_series_cv`.
    *   You can select models, define CV parameters, and view results (mean metrics table and boxplots of metric distributions).
    *   Models are retrained on each CV slice using their original configurations.

5.  **NNETAR Model Integration:**
    *   I integrated the NNETAR (Neural Network Autoregressive) model.
    *   I added UI controls for NNETAR configuration.
    *   I implemented `train_nnetar` and `forecast_nnetar` utility functions.
    *   NNETAR is now available in the main forecasting workflow and the new cross-validation section.

**Areas for Potential Review/Further Enhancement (as per your request):**

*   **Load Session - File Input Restoration:** The current load functionality restores configuration and reactive states. True restoration of `fileInput` widgets (main data, holidays) is complex; you are currently guided to re-upload. Let me know if a more seamless experience for file reloading is desired.
*   **CV - XGBoost/RF Parameter Handling:** In the CV loop, tree-based models (XGBoost, RF) currently use their original configuration (which might be tuned parameters from the main run, or default/manual if tuning was off). Re-tuning these models on each CV slice is computationally very expensive and thus not implemented. Let me know if this approach is adequate or if a strategy for handling tuned parameters vs. re-tuning in CV is needed.
*   **CV - `slice_limit`:** The `slice_limit` in `timetk::time_series_cv` is currently hardcoded. Consider if this should be user-configurable for more/less granular CV.
*   **Error Handling in CV Loops:** While `tryCatch` is used for individual model folds, more granular error reporting or alternative behaviors for specific model failures during CV could be explored.
*   **NNETAR Configuration:** The `nnetar` UI offers several parameters. Let me know if the defaults and ranges are optimal or if further refinement/simplification is needed. Prediction intervals for NNETAR can sometimes be missing; the code attempts to handle this by adding NA columns.
*   **State Restoration Granularity:** The load functionality restores many input values directly. Let me know if all modules correctly re-trigger downstream reactives upon these updates, or if more explicit re-triggering mechanisms are needed for some parts of the app after loading a session.